### PR TITLE
Setting overflow-scrolling to touch

### DIFF
--- a/dist/my-crappy-homepage-app.html
+++ b/dist/my-crappy-homepage-app.html
@@ -8327,7 +8327,8 @@ document.
             line-height: 1.33;
             font-family: "Computer Modern Serif", serif;
             -webkit-font-smoothing: antialiased;
-            overflow: auto;
+            overflow-y: scroll;
+            -webkit-overflow-scrolling: touch;
             padding: 30px;
             color: rgb(50, 50, 50);
         }

--- a/src/my-crappy-homepage-app/my-crappy-homepage-app.html
+++ b/src/my-crappy-homepage-app/my-crappy-homepage-app.html
@@ -66,7 +66,8 @@
             line-height: 1.33;
             font-family: "Computer Modern Serif", serif;
             -webkit-font-smoothing: antialiased;
-            overflow: auto;
+            overflow-y: scroll;
+            -webkit-overflow-scrolling: touch;
             padding: 30px;
             color: rgb(50, 50, 50);
         }


### PR DESCRIPTION
When scrolling on mobile, there is no _momentum scroll_, the page stops scrolling as soon as the finger moves away from the screen.

This PR fixes that.
